### PR TITLE
Avoiding Body() calls in components and refactoring route, component and model processors

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/factorapp/factor/component"
+	"github.com/factorapp/factor/model"
 	"github.com/spf13/cobra"
 )
 
@@ -62,7 +63,7 @@ func build() error {
 	}
 
 	dir = filepath.Join(cwd, "models")
-	err = processModels(dir)
+	err = model.ProcessAll(dir)
 	if err != nil {
 		return err
 	}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/factorapp/factor/component"
 	"github.com/spf13/cobra"
 )
 
@@ -49,13 +50,13 @@ func build() error {
 	}
 
 	dir := filepath.Join(cwd, "components")
-	err = processComponents(dir, "components")
+	err = component.ProcessAll(dir, "components")
 	if err != nil {
 		return err
 	}
 
 	dir = filepath.Join(cwd, "routes")
-	err = processComponents(dir, "routes")
+	err = component.ProcessAll(dir, "routes")
 	if err != nil {
 		return err
 	}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/factorapp/factor/component"
 	"github.com/factorapp/factor/model"
+	"github.com/factorapp/factor/route"
 	"github.com/spf13/cobra"
 )
 
@@ -51,13 +52,15 @@ func build() error {
 	}
 
 	dir := filepath.Join(cwd, "components")
-	err = component.ProcessAll(dir, "components")
+	// err = component.ProcessAll(dir, "components")
+	err = component.ProcessAll(dir)
 	if err != nil {
 		return err
 	}
 
 	dir = filepath.Join(cwd, "routes")
-	err = component.ProcessAll(dir, "routes")
+	// err = component.ProcessAll(dir, "routes")
+	err = route.ProcessAll(dir)
 	if err != nil {
 		return err
 	}

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -15,14 +15,9 @@
 package cmd
 
 import (
-	"io"
 	"log"
 	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
 
-	"github.com/factorapp/factor/component"
 	"github.com/spf13/cobra"
 )
 
@@ -52,77 +47,6 @@ to quickly create a Cobra application.`,
 		}
 
 	},
-}
-
-func processComponents(base string, packageName string) error {
-
-	err := filepath.Walk(base, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() && isHtml(info) {
-			f, err := os.Open(path)
-			if err != nil {
-				return err
-			}
-			//c, _ := component.Parse(f, componentName(path))
-
-			comp := componentName(path)
-			gfn := filepath.Join(base, strings.ToLower(comp)+".go")
-			_, err = os.Stat(gfn)
-			var makeStruct bool
-			if os.IsNotExist(err) {
-				makeStruct = true
-			}
-			/*gofile, err := os.Create(goFileName(base, componentName(path)))
-			if err != nil {
-				return err
-			}
-			defer gofile.Close()
-
-			c.Transform(gofile)
-			*/
-			transpiler, err := component.NewTranspiler(f, makeStruct, comp, packageName)
-			if err != nil {
-				log.Println("ERROR", err)
-				return err
-			}
-
-			gofile, err := os.Create(goFileName(base, comp))
-			if err != nil {
-				log.Println("ERROR", err)
-				return err
-			}
-			defer gofile.Close()
-			_, err = io.WriteString(gofile, transpiler.Code())
-			if err != nil {
-				log.Println("ERROR", err)
-				return err
-			}
-		}
-		return nil
-	})
-
-	if err != nil {
-		log.Printf("error walking the path %q: %v\n", base, err)
-	}
-	return err
-}
-func isHtml(info os.FileInfo) bool {
-	return filepath.Ext(info.Name()) == ".html"
-}
-
-func goFileName(base, comp string) string {
-	return filepath.Join(base, strings.ToLower(comp)+"_generated.go")
-}
-func componentName(path string) string {
-	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
-	if err != nil {
-		log.Fatal(err)
-	}
-	base := filepath.Base(path)
-	base = strings.Replace(base, filepath.Ext(path), "", -1)
-	return strings.Title(reg.ReplaceAllString(base, ""))
 }
 
 func init() {

--- a/codegen/compnav.go
+++ b/codegen/compnav.go
@@ -12,7 +12,7 @@ import (
 
 type Nav struct {
 	vecty.Core
-	MyProp      string ` + "`" + "vecty:" + `"Prop"
+	MyProp      string ` + "`" + "vecty:" + `"Prop"` + "`" + `
 	CurrentPath string
 }
 `

--- a/component/process.go
+++ b/component/process.go
@@ -5,8 +5,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
+
+	"github.com/factorapp/factor/files"
 )
 
 // ProcessAll processes components starting at base
@@ -16,14 +17,14 @@ func ProcessAll(base string) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() && isHTML(info) {
+		if !info.IsDir() && files.IsHTML(info) {
 			f, err := os.Open(path)
 			if err != nil {
 				return err
 			}
 			//c, _ := component.Parse(f, componentName(path))
 
-			comp := componentName(path)
+			comp := files.ComponentName(path)
 			gfn := filepath.Join(base, strings.ToLower(comp)+".go")
 			_, err = os.Stat(gfn)
 			var makeStruct bool
@@ -44,7 +45,7 @@ func ProcessAll(base string) error {
 				return err
 			}
 
-			gofile, err := os.Create(goFileName(base, comp))
+			gofile, err := os.Create(files.GeneratedGoFileName(base, comp))
 			if err != nil {
 				log.Println("ERROR", err)
 				return err
@@ -63,21 +64,4 @@ func ProcessAll(base string) error {
 		log.Printf("error walking the path %q: %v\n", base, err)
 	}
 	return err
-}
-
-func isHTML(info os.FileInfo) bool {
-	return filepath.Ext(info.Name()) == ".html"
-}
-
-func goFileName(base, comp string) string {
-	return filepath.Join(base, strings.ToLower(comp)+"_generated.go")
-}
-func componentName(path string) string {
-	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
-	if err != nil {
-		log.Fatal(err)
-	}
-	base := filepath.Base(path)
-	base = strings.Replace(base, filepath.Ext(path), "", -1)
-	return strings.Title(reg.ReplaceAllString(base, ""))
 }

--- a/component/process.go
+++ b/component/process.go
@@ -1,0 +1,83 @@
+package component
+
+import (
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ProcessAll processes components starting at base
+func ProcessAll(base string, packageName string) error {
+
+	err := filepath.Walk(base, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && isHTML(info) {
+			f, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			//c, _ := component.Parse(f, componentName(path))
+
+			comp := componentName(path)
+			gfn := filepath.Join(base, strings.ToLower(comp)+".go")
+			_, err = os.Stat(gfn)
+			var makeStruct bool
+			if os.IsNotExist(err) {
+				makeStruct = true
+			}
+			/*gofile, err := os.Create(goFileName(base, componentName(path)))
+			if err != nil {
+				return err
+			}
+			defer gofile.Close()
+
+			c.Transform(gofile)
+			*/
+			transpiler, err := NewTranspiler(f, makeStruct, comp, packageName)
+			if err != nil {
+				log.Println("ERROR", err)
+				return err
+			}
+
+			gofile, err := os.Create(goFileName(base, comp))
+			if err != nil {
+				log.Println("ERROR", err)
+				return err
+			}
+			defer gofile.Close()
+			_, err = io.WriteString(gofile, transpiler.Code())
+			if err != nil {
+				log.Println("ERROR", err)
+				return err
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		log.Printf("error walking the path %q: %v\n", base, err)
+	}
+	return err
+}
+
+func isHTML(info os.FileInfo) bool {
+	return filepath.Ext(info.Name()) == ".html"
+}
+
+func goFileName(base, comp string) string {
+	return filepath.Join(base, strings.ToLower(comp)+"_generated.go")
+}
+func componentName(path string) string {
+	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
+	if err != nil {
+		log.Fatal(err)
+	}
+	base := filepath.Base(path)
+	base = strings.Replace(base, filepath.Ext(path), "", -1)
+	return strings.Title(reg.ReplaceAllString(base, ""))
+}

--- a/component/transpiler.go
+++ b/component/transpiler.go
@@ -56,9 +56,6 @@ func (s *Transpiler) read() error {
 	s.html = string(bb)
 	return nil
 }
-func (s *Transpiler) Html() string {
-	return s.html
-}
 
 func (s *Transpiler) Code() string {
 	return s.code

--- a/component/transpiler.go
+++ b/component/transpiler.go
@@ -534,12 +534,21 @@ func (s *Transpiler) transcode() error {
 			jen.Qual("github.com/gowasm/vecty", "Core"),
 		)
 	}
-	file.Func().Params(jen.Id("p").Op("*").Id(s.componentName)).Id("Render").Params().Qual("github.com/gowasm/vecty", "ComponentOrHTML").Block(
-		jen.Return(
-			// TODO: wrap in if - only body for a "route"
-			jen.Qual("github.com/gowasm/vecty/elem", "Body").Custom(call, elements...),
-		),
-	)
+	if s.packageName == "routes" {
+		file.Func().Params(jen.Id("p").Op("*").Id(s.componentName)).Id("Render").Params().Qual("github.com/gowasm/vecty", "ComponentOrHTML").Block(
+			jen.Return(
+				// TODO: wrap in if - only body for a "route"
+				jen.Qual("github.com/gowasm/vecty/elem", "Body").Custom(call, elements...),
+			),
+		)
+	} else {
+		file.Func().Params(jen.Id("p").Op("*").Id(s.componentName)).Id("Render").Params().Qual("github.com/gowasm/vecty", "ComponentOrHTML").Block(
+			jen.Return(
+				// TODO: wrap in if - only body for a "route"
+				jen.Qual("github.com/gowasm/vecty/elem", "Markup").Custom(call, elements...),
+			),
+		)
+	}
 	/*if len(elements) == 1 {
 		file.Var().Id("Element").Op("=").Add(elements[0])
 	} else if len(elements) > 1 {

--- a/component/transpiler.go
+++ b/component/transpiler.go
@@ -19,6 +19,9 @@ import (
 	"github.com/dave/jennifer/jen"
 )
 
+var callRegexp = regexp.MustCompile(`{vecty-call:([a-zA-Z0-9_\-]+)}`)
+var fieldRegexp = regexp.MustCompile(`{vecty-field:([a-zA-Z0-9_\-]+})`)
+
 func NewTranspiler(r io.ReadCloser, createStruct bool, componentName, packageName string) (*Transpiler, error) {
 	s := &Transpiler{
 		reader:        r,
@@ -82,9 +85,6 @@ func (s *Transpiler) transcode() error {
 		Open:      "{",
 		Separator: ",",
 	}*/
-
-	callRegexp := regexp.MustCompile(`{vecty-call:([a-zA-Z0-9_\-]+)}`)
-	fieldRegexp := regexp.MustCompile(`{vecty-field:([a-zA-Z0-9_\-]+})`)
 
 	var transcode func(*xml.Decoder) (jen.Code, error)
 	transcode = func(decoder *xml.Decoder) (code jen.Code, err error) {

--- a/files/file_types.go
+++ b/files/file_types.go
@@ -1,0 +1,27 @@
+package files
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var reg = regexp.MustCompile("[^a-zA-Z0-9]+")
+
+func IsHTML(info os.FileInfo) bool {
+	return filepath.Ext(info.Name()) == ".html"
+}
+
+func GeneratedGoFileName(base, name string) string {
+	return filepath.Join(base, strings.ToLower(name)+"_generated.go")
+}
+func ComponentName(path string) string {
+	base := filepath.Base(path)
+	base = strings.Replace(base, filepath.Ext(path), "", -1)
+	return strings.Title(reg.ReplaceAllString(base, ""))
+}
+
+func RouteName(path string) string {
+	return ComponentName(path)
+}

--- a/model/process.go
+++ b/model/process.go
@@ -1,15 +1,14 @@
-package cmd
+package model
 
 import (
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/factorapp/factor/model"
 )
 
-func processModels(base string) error {
+// ProcessAll processes models starting at base
+func ProcessAll(base string) error {
 	servers := []string{}
 	clients := []string{}
 	err := filepath.Walk(base, func(path string, info os.FileInfo, err error) error {
@@ -22,7 +21,7 @@ func processModels(base string) error {
 		if !isModel(info) {
 			return nil
 		}
-		model := model.New(path, info)
+		model := New(path, info)
 
 		typesFilename := filepath.Join(base, model.TypesFilename())
 		log.Printf("generating %s", typesFilename)
@@ -61,7 +60,7 @@ func processModels(base string) error {
 	if err != nil {
 		return err
 	}
-	if err := model.WriteClientFile(clientFd, clients); err != nil {
+	if err := WriteClientFile(clientFd, clients); err != nil {
 		return err
 	}
 
@@ -70,7 +69,7 @@ func processModels(base string) error {
 	if err != nil {
 		return err
 	}
-	if err := model.WriteServerFile(serverFd); err != nil {
+	if err := WriteServerFile(serverFd); err != nil {
 		return err
 	}
 	log.Printf("generated servers and clients: %s", servers)

--- a/route/process.go
+++ b/route/process.go
@@ -1,4 +1,4 @@
-package component
+package route
 
 import (
 	"io"
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/factorapp/factor/component"
 )
 
 // ProcessAll processes components starting at base
@@ -38,7 +40,7 @@ func ProcessAll(base string) error {
 
 			c.Transform(gofile)
 			*/
-			transpiler, err := NewTranspiler(f, makeStruct, comp, "components")
+			transpiler, err := component.NewTranspiler(f, makeStruct, comp, "routes")
 			if err != nil {
 				log.Println("ERROR", err)
 				return err


### PR DESCRIPTION
Fixes #12 

routes still have a duplicate elem.Body though - I'll fix that in another PR. I need to also break some code out of the transpiler in a follow-up